### PR TITLE
[VM] mmap implementation (except page-parallel, page-merge-mm)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .vscode/
+vm/build
+userprog/build
+memo/

--- a/filesys/inode.c
+++ b/filesys/inode.c
@@ -181,11 +181,13 @@ inode_remove (struct inode *inode) {
  * than SIZE if an error occurs or end of file is reached. */
 off_t
 inode_read_at (struct inode *inode, void *buffer_, off_t size, off_t offset) {
+	//printf("[inode_read_ate] start\n");
 	uint8_t *buffer = buffer_;
 	off_t bytes_read = 0;
 	uint8_t *bounce = NULL;
 
 	while (size > 0) {
+		//printf("[inode_read_ate] while start\n");
 		/* Disk sector to read, starting byte offset within sector. */
 		disk_sector_t sector_idx = byte_to_sector (inode, offset);
 		int sector_ofs = offset % DISK_SECTOR_SIZE;
@@ -197,31 +199,42 @@ inode_read_at (struct inode *inode, void *buffer_, off_t size, off_t offset) {
 
 		/* Number of bytes to actually copy out of this sector. */
 		int chunk_size = size < min_left ? size : min_left;
-		if (chunk_size <= 0)
+		if (chunk_size <= 0){
+			//printf("[inode_read_ate] chunk_size <= 0\n");
 			break;
+		}
+			
 
 		if (sector_ofs == 0 && chunk_size == DISK_SECTOR_SIZE) {
 			/* Read full sector directly into caller's buffer. */
+			//printf("[inode_read_ate] second if start\n");
 			disk_read (filesys_disk, sector_idx, buffer + bytes_read); 
 		} else {
 			/* Read sector into bounce buffer, then partially copy
 			 * into caller's buffer. */
+			//printf("[inode_read_ate] first else start\n");
 			if (bounce == NULL) {
+				//printf("[inode_read_ate] third if start and 'bounce == NULL'\n");
 				bounce = malloc (DISK_SECTOR_SIZE);
-				if (bounce == NULL)
-					break;
+				if (bounce == NULL) {
+					//printf("[inode_read_ate] bounce == NULL\n");
+					break;}
 			}
+			//printf("[inode_read_ate] 1\n");
 			disk_read (filesys_disk, sector_idx, bounce);
-			memcpy (buffer + bytes_read, bounce + sector_ofs, chunk_size);
+			//printf("[inode_read_ate] 2\n");
+			memcpy (buffer + bytes_read, bounce + sector_ofs, chunk_size);//
+			//printf("[inode_read_ate] first else end\n");
 		}
 
 		/* Advance. */
 		size -= chunk_size;
 		offset += chunk_size;
 		bytes_read += chunk_size;
+		//printf("[inode_read_ate] while end\n");
 	}
 	free (bounce);
-
+	//printf("[inode_read_ate] end\n");
 	return bytes_read;
 }
 

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -135,6 +135,8 @@ struct thread {
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */
 	struct supplemental_page_table spt;
+	/* Save rsp when interrupt occured. */
+	uintptr_t intr_rsp;
 #endif
 
 	/* Owned by thread.c. */

--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -10,7 +10,7 @@ int process_exec (void *f_name);
 int process_wait (tid_t);
 void process_exit (void);
 void process_activate (struct thread *next);
-
+// #ifdef VM
 /*project 3*/
 // for load_segment - aux
 struct load_info {
@@ -21,6 +21,6 @@ struct load_info {
     uint32_t zero_bytes;
     bool writable;
 };
-
+// #endif
 
 #endif /* userprog/process.h */

--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -11,4 +11,16 @@ int process_wait (tid_t);
 void process_exit (void);
 void process_activate (struct thread *next);
 
+/*project 3*/
+// for load_segment - aux
+struct load_info {
+    struct file *file;
+    off_t ofs;
+    uint8_t *upage;
+    uint32_t read_bytes;
+    uint32_t zero_bytes;
+    bool writable;
+};
+
+
 #endif /* userprog/process.h */

--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -10,6 +10,9 @@ int process_exec (void *f_name);
 int process_wait (tid_t);
 void process_exit (void);
 void process_activate (struct thread *next);
+
+bool lazy_load_segment (struct page *page, void *aux);
+
 // #ifdef VM
 /*project 3*/
 // for load_segment - aux

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -63,6 +63,7 @@ struct page {
 	/* project 3 */
 	struct hash_elem hash_elem; /* Hash table element. */
 	bool writable;
+	int mapped_page_count;
 };
 
 /* The representation of "frame" */

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -2,6 +2,8 @@
 #define VM_VM_H
 #include <stdbool.h>
 #include "threads/palloc.h"
+/* project 3 */
+#include "lib/kernel/hash.h"
 
 enum vm_type {
 	/* page not initialized */
@@ -57,6 +59,10 @@ struct page {
 		struct page_cache page_cache;
 #endif
 	};
+
+	/* project 3 */
+	struct hash_elem hash_elem; /* Hash table element. */
+	bool writable;
 };
 
 /* The representation of "frame" */
@@ -85,6 +91,7 @@ struct page_operations {
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
 struct supplemental_page_table {
+	struct hash spt_hash; /* hash table : should not access directly */
 };
 
 #include "threads/thread.h"

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -69,6 +69,7 @@ struct page {
 struct frame {
 	void *kva;
 	struct page *page;
+	struct list_elem frame_elem;
 };
 
 /* The function table for page operations.

--- a/lib/kernel/hash.c
+++ b/lib/kernel/hash.c
@@ -92,9 +92,14 @@ struct hash_elem *
 hash_insert (struct hash *h, struct hash_elem *new) {
 	struct list *bucket = find_bucket (h, new);
 	struct hash_elem *old = find_elem (h, bucket, new);
+	//printf("[hash_insert] %p, %p, %p\n", bucket, old, new);
 
-	if (old == NULL)
+	if (old == NULL){
+		//printf("[hash_insert] old==NULL\n");
 		insert_elem (h, bucket, new);
+		//printf("[hash_insert] inserted finished\n");
+	}
+		
 
 	rehash (h);
 
@@ -121,6 +126,7 @@ hash_replace (struct hash *h, struct hash_elem *new) {
    null pointer if no equal element exists in the table. */
 struct hash_elem *
 hash_find (struct hash *h, struct hash_elem *e) {
+	//printf("[hash_find] h: %p /hash_elem: %p \n");
 	return find_elem (h, find_bucket (h, e), e);
 }
 
@@ -275,7 +281,7 @@ uint64_t
 hash_int (int i) {
 	return hash_bytes (&i, sizeof i);
 }
-
+
 /* Returns the bucket in H that E belongs in. */
 static struct list *
 find_bucket (struct hash *h, struct hash_elem *e) {

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -669,6 +669,8 @@ init_thread (struct thread *t, const char *name, int priority) {
 	// // t->fd_table[1] = 1;
 	// t->next_fd = 2;
 	// t->fd_table -= 2;
+
+	
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -145,45 +145,46 @@ page_fault (struct intr_frame *f) {
 	// printf("page fault at %p\n", fault_addr);
 	/* Handle kernel-mode page faults. */
 	if (!user) {
-		// printf("not user\n");
-		if (is_kernel_vaddr(fault_addr)) {
-			// printf("is kernel vaddr\n");
-			if (fault_addr >= PHYS_BASE) {
-				// printf("fault addr >= phys base\n");
-				exit(-1);
-			}
-			else {
-				// printf("fault addr < phys base\n");
-			}
+		// printf("[page_fault] not user\n");
+		// if (is_kernel_vaddr(fault_addr)) {
+		// 	//printf("[page_fault] is kernel vaddr\n");
+		// 	if (fault_addr >= PHYS_BASE) {
+		// 		//printf("[page_fault] fault addr >= phys base\n");
+		// 		exit(-1);
+		// 	}
+		// 	else {
+		// 		//printf("[page_fault] fault addr < phys base\n");
+		// 	}
 
-		}
+		// }
 
-		else {
-			// printf("not kernel vaddr\n");
-			exit(-1);
-		}
+		// else {
+		// 	//printf("[page_fault] not kernel vaddr\n");
+		// 	exit(-1);
+		// }
 	}
 
 	/* Handle user-mode page faults. */
 	else {
 		// printf("user\n");
 		if (is_kernel_vaddr(fault_addr)) {
-			// printf("is kernel vaddr\n");
-			exit(-1);
-		}
+			//printf("[page_fault] is kernel vaddr\n");
+			exit(-1); 
+		} 
 		else {
-			// printf("not kernel vaddr\n");
+			//printf("[page_fault] not kernel vaddr\n");
 			if (fault_addr <= VIRTUAL_BASE) {
-				// printf("fault addr <= virtual base\n");
+				//printf("[page_fault] fault addr <= virtual base\n");
 				exit(-1);
 			} else {
-				// printf("fault addr > virtual base\n");
+				//printf("[page_fault] fault addr > virtual base\n");
 			}
 		}
 	}
 
 #ifdef VM
 	/* For project 3 and later. */
+	//printf("[page_fault] vm try handle fault start...\n");
 	if (vm_try_handle_fault (f, fault_addr, user, write, not_present))
 		return;
 #endif

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -142,54 +142,21 @@ page_fault (struct intr_frame *f) {
 
 	int PHYS_BASE = 0x80040000;
 	int VIRTUAL_BASE = 0x00000000;
-	// printf("page fault at %p\n", fault_addr);
-	/* Handle kernel-mode page faults. */
-	if (!user) {
-		// printf("[page_fault] not user\n");
-		// if (is_kernel_vaddr(fault_addr)) {
-		// 	//printf("[page_fault] is kernel vaddr\n");
-		// 	if (fault_addr >= PHYS_BASE) {
-		// 		//printf("[page_fault] fault addr >= phys base\n");
-		// 		exit(-1);
-		// 	}
-		// 	else {
-		// 		//printf("[page_fault] fault addr < phys base\n");
-		// 	}
-
-		// }
-
-		// else {
-		// 	//printf("[page_fault] not kernel vaddr\n");
-		// 	exit(-1);
-		// }
-	}
-
-	/* Handle user-mode page faults. */
-	else {
-		// printf("user\n");
-		if (is_kernel_vaddr(fault_addr)) {
-			//printf("[page_fault] is kernel vaddr\n");
-			exit(-1); 
-		} 
-		else {
-			//printf("[page_fault] not kernel vaddr\n");
-			if (fault_addr <= VIRTUAL_BASE) {
-				//printf("[page_fault] fault addr <= virtual base\n");
-				exit(-1);
-			} else {
-				//printf("[page_fault] fault addr > virtual base\n");
-			}
-		}
-	}
 
 #ifdef VM
 	/* For project 3 and later. */
 	//printf("[page_fault] vm try handle fault start...\n");
-	if (vm_try_handle_fault (f, fault_addr, user, write, not_present))
+	if (vm_try_handle_fault (f, fault_addr, user, write, not_present)){
+		//printf("[page_fault] vm try handle fault ends...\n");
 		return;
+	}
 #endif
 
 	/* Count page faults. */
+	if(user) {
+		//printf("[page_fault] user error, goes to exit(-1)\n");
+		exit(-1);
+	}
 	page_fault_cnt++;
 
 	/* If the fault is true fault, show info and exit. */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -723,7 +723,7 @@ lazy_load_segment (struct page *page, void *aux) {
 		return false;
 	}
 	memset(page->frame->kva + page_read_bytes, 0, page_zero_bytes);
-	// free(aux);
+	free(aux);
 	//printf("[lazy load segment] end\n");
 	return true;
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -30,6 +30,7 @@ static void __do_fork (void *);
 /* General process initializer for initd and other process. */
 static void
 process_init (void) {
+	//printf("[process_init]실행\n");
 	struct thread *current = thread_current ();
 }
 
@@ -207,6 +208,7 @@ error:
  * Returns -1 on fail. */
 int
 process_exec (void *f_name) {
+	//printf("[process_exec] 실행\n");
 	char *file_name = (char *)palloc_get_page(PAL_ZERO);
 	strlcpy(file_name, (char *)f_name, strlen(f_name) + 1);
 	bool success;
@@ -227,12 +229,15 @@ process_exec (void *f_name) {
     int argc = 0;
 	tokenizer(file_name, argv, &argc);
 	/* project 2: argument passing */
+	//printf("[process_exec] tokenizer end\n");
 
 	/* And then load the binary */
 	success = load (file_name, &_if);
+	//printf("[process_exec] load end: %d\n", success);
 
 	/* If load failed, quit. */
 	if (!success) {
+		//printf("[process_exec] load failed\n");
 		palloc_free_page (file_name);
 		return -1;
 	}
@@ -244,11 +249,16 @@ process_exec (void *f_name) {
 	// hex_dump(_if.rsp, _if.rsp, USER_STACK-_if.rsp, true);
 	/* project 2: argument passing */
 
+	//printf("[process_exec] stacker end\n");
+
 	palloc_free_page (file_name);
+	//printf("[process_exec] palloc free page end\n");
 
 	/* Start switched process. */
 	do_iret (&_if);
+	//printf("[process_exec] do_iret end\n");
 	NOT_REACHED ();
+	//printf("process_exec end\n");
 }
 
 
@@ -404,6 +414,7 @@ static bool load_segment (struct file *file, off_t ofs, uint8_t *upage,
 extern struct lock file_lock;
 static bool
 load (const char *file_name, struct intr_frame *if_) {
+	//printf("[load] 실행\n");
 	struct thread *t = thread_current ();
 	struct ELF ehdr;
 	struct file *file = NULL;
@@ -413,8 +424,9 @@ load (const char *file_name, struct intr_frame *if_) {
 
 	/* Allocate and activate page directory. */
 	t->pml4 = pml4_create ();
-	if (t->pml4 == NULL)
-		goto done;
+	if (t->pml4 == NULL){
+		//printf("[load] pml4 == NULL\n");
+		goto done;}
 	process_activate (thread_current ());
 
 	/* Open executable file. */
@@ -429,6 +441,8 @@ load (const char *file_name, struct intr_frame *if_) {
 	t->running = file;
 	file_deny_write(file);
 
+	//printf("[load] file_deny_write after\n");
+
 	/* Read and verify executable header. */
 	if (file_read (file, &ehdr, sizeof ehdr) != sizeof ehdr
 			|| memcmp (ehdr.e_ident, "\177ELF\2\1\1", 7)
@@ -440,6 +454,8 @@ load (const char *file_name, struct intr_frame *if_) {
 		printf ("load: %s: error loading executable\n", file_name);
 		goto done;
 	}
+
+	//printf("[load] file_read finished\n");
 
 	/* Read program headers. */
 	file_ofs = ehdr.e_phoff;
@@ -494,19 +510,27 @@ load (const char *file_name, struct intr_frame *if_) {
 		}
 	}
 
+	
+	//printf("[load] setup stack now starting..\n");
 	/* Set up stack. */
-	if (!setup_stack (if_))
+	if (!setup_stack (if_)){
+		//printf("[load] setup sta failed\n");
 		goto done;
-
+		}
+	//printf("[load] setup stack is finished..\n");
 	/* Start address. */
 	if_->rip = ehdr.e_entry;
 
+	//printf("[load] if_->rip.. \n");
+
+
 	/* TODO: Your code goes here.
 	 * TODO: Implement argument passing (see project2/argument_passing.html). */
-
+	//printf("[load] end safely \n");
 	success = true;
 
 done:
+	//printf("[load] end in done\n");
 	/* We arrive here whether the load is successful or not. */
 	return success;
 }
@@ -556,7 +580,7 @@ validate_segment (const struct Phdr *phdr, struct file *file) {
 	return true;
 }
 
-#ifndef VM
+#ifndef VM 
 /* Codes of this block will be ONLY USED DURING project 2.
  * If you want to implement the function for whole project 2, implement it
  * outside of #ifndef macro. */
@@ -623,6 +647,7 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 /* Create a minimal stack by mapping a zeroed page at the USER_STACK */
 static bool
 setup_stack (struct intr_frame *if_) {
+	//printf("[setup_stack] start\n");
 	uint8_t *kpage;
 	bool success = false;
 
@@ -655,16 +680,53 @@ install_page (void *upage, void *kpage, bool writable) {
 	return (pml4_get_page (t->pml4, upage) == NULL
 			&& pml4_set_page (t->pml4, upage, kpage, writable));
 }
-#else
+#else 
 /* From here, codes will be used after project 3.
  * If you want to implement the function for only project 2, implement it on the
  * upper block. */
 
 static bool
 lazy_load_segment (struct page *page, void *aux) {
-	/* TODO: Load the segment from the file */
+	//printf("[lazy load segment] 실행\n");
 	/* TODO: This called when the first page fault occurs on address VA. */
 	/* TODO: VA is available when calling this function. */
+
+	/* TODO: Load the segment from the file */
+	// get arguments info passed by aux 
+	struct load_info *arguments = aux;
+	struct file *file = arguments->file;
+	off_t ofs = arguments->ofs;
+	uint8_t* upage = arguments->upage;
+	uint32_t read_bytes = arguments->read_bytes;
+	uint32_t zero_bytes = arguments->zero_bytes;
+	bool writable = arguments->writable;
+
+	file_seek(file, ofs);
+
+	/* Do calculate how to fill this page.
+	 * We will read PAGE_READ_BYTES bytes from FILE
+	 * and zero the final PAGE_ZERO_BYTES bytes. */
+	size_t page_read_bytes = read_bytes;
+	size_t page_zero_bytes = zero_bytes;
+
+	/* Get a page of memory: use frame*/
+	if(page->frame->kva == NULL) {
+		palloc_free_page(page->frame->kva);
+		free(aux);
+		return false;
+	}
+
+	/* Load this page. */
+	if(file_read(file, page->frame->kva, page_read_bytes) != (int) page_read_bytes) {
+		palloc_free_page(page->frame->kva);
+		free(aux);
+		return false;
+	}
+	memset(page->frame->kva + page_read_bytes, 0, page_zero_bytes);
+	// free(aux);
+	//printf("[lazy load segment] end\n");
+	return true;
+
 }
 
 /* Loads a segment starting at offset OFS in FILE at address
@@ -684,6 +746,7 @@ lazy_load_segment (struct page *page, void *aux) {
 static bool
 load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
+	//printf("[load segment] 실행\n");
 	ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);
 	ASSERT (pg_ofs (upage) == 0);
 	ASSERT (ofs % PGSIZE == 0);
@@ -696,7 +759,15 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
 		/* TODO: Set up aux to pass information to the lazy_load_segment. */
-		void *aux = NULL;
+		struct load_info* aux = malloc(sizeof(struct load_info));
+		// insert the given arguments
+		aux->file = file;
+		aux->ofs = ofs;
+		aux->upage = upage;
+		aux->read_bytes = read_bytes;
+		aux->zero_bytes = zero_bytes;
+		aux->writable = writable;
+		
 		if (!vm_alloc_page_with_initializer (VM_ANON, upage,
 					writable, lazy_load_segment, aux))
 			return false;
@@ -705,24 +776,45 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		read_bytes -= page_read_bytes;
 		zero_bytes -= page_zero_bytes;
 		upage += PGSIZE;
+
+		/* update ofs */
+		ofs += page_read_bytes;
 	}
+	//printf("[load segment] 끝\n");
 	return true;
 }
 
 /* Create a PAGE of stack at the USER_STACK. Return true on success. */
 static bool
 setup_stack (struct intr_frame *if_) {
+	//printf("[setup_stack] 실행\n");
 	bool success = false;
 	void *stack_bottom = (void *) (((uint8_t *) USER_STACK) - PGSIZE);
 
-	/* TODO: Map the stack on stack_bottom and claim the page immediately.
-	 * TODO: If success, set the rsp accordingly.
+	/* TODO: Map the stack on stack_bottom and claim the page immediately.*/
+	if(!vm_alloc_page(VM_ANON, stack_bottom, true)){ 
+		return false;
+	}
+	success = vm_claim_page(stack_bottom);
+
+	//printf("[setup_stack] success: %d\n", success);
+
+	//printf("[setupt stack] succ?:%d\n", success);
+	/* TODO: If success, set the rsp accordingly.
 	 * TODO: You should mark the page is stack. */
 	/* TODO: Your code goes here */
+	//if_->rsp = USER_STACK;
+	if (success) {
+		if_->rsp = USER_STACK;
+		//printf("[setup_stack] if_->rsp %p\n",if_->rsp);
+	}
+
+	//printf("[setup_stack] end\n");
+	
 
 	return success;
 }
-#endif /* VM */
+#endif /* VM */ 
 
 
 void tokenizer(char *file_name, char **argv, int *argc) {
@@ -736,6 +828,7 @@ void tokenizer(char *file_name, char **argv, int *argc) {
 }
 
 void stacker(char **argv, int argc, struct intr_frame *if_) {
+	//printf("[staker] staker start\n");
 	/* stacking variables */
 	char *addrs[MAX_ARGS];
 	int i = argc-1;
@@ -746,29 +839,32 @@ void stacker(char **argv, int argc, struct intr_frame *if_) {
 		strlcpy(if_->rsp, argv[i], arglen + 1);
 		addrs[i--] = if_->rsp;
 	}
-
+	//printf("[staker] staker while 1 end\n");
 	/* padding aligning */
 	while (if_->rsp % 8 != 0) {
 		// printf("padding 1 at %p\n", if_->rsp-1);
 		if_->rsp--;
 		*(uint8_t *)if_->rsp = 0;
 	}
-
+	//printf("[staker] staker while 2 end\n");
 	/* null pointer sentiel */
-	// printf("border at %p\n", if_->rsp-8);
+	//printf("[staker] border at %p\n", if_->rsp-8);
 	if_->rsp -= 8;
 	*(uint64_t *)if_->rsp = 0;
-
+	//printf("[staker] 3 end\n");
 	/* stacking addresses */
 	i = argc-1;
 	while (i >= 0) {
-		// printf("stacking %p at %p\n", addrs[i], if_->rsp-8);
+		//printf("[staker] staker while 3 end\n");
+		//printf("[staker] stacking %p at %p\n", addrs[i], if_->rsp-8);
 		if_->rsp -= 8;
 		*(uint64_t *)if_->rsp = (uint64_t)addrs[i--];
 	}
 	
 	/* fake return address */
-	// printf("fake return address at %p\n", if_->rsp-8);
+	//printf("[staker] fake return address at %p\n", if_->rsp-8);
+	//printf("[staker] 4 end\n");
 	if_->rsp -= 8;
 	*(uint64_t *)if_->rsp = 0;
+	//printf("[staker] staker end\n");
 }

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -20,13 +20,15 @@
 #include "intrinsic.h"
 #ifdef VM
 #include "vm/vm.h"
+#include "vm/file.h"
 #endif
 
 static void process_cleanup (void);
 static bool load (const char *file_name, struct intr_frame *if_);
 static void initd (void *f_name);
 static void __do_fork (void *);
-
+/*project 2 and 3*/
+extern struct lock file_lock;
 /* General process initializer for initd and other process. */
 static void
 process_init (void) {
@@ -411,7 +413,7 @@ static bool load_segment (struct file *file, off_t ofs, uint8_t *upage,
  * Stores the executable's entry point into *RIP
  * and its initial stack pointer into *RSP.
  * Returns true if successful, false otherwise. */
-extern struct lock file_lock;
+
 static bool
 load (const char *file_name, struct intr_frame *if_) {
 	//printf("[load] 실행\n");

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -687,7 +687,7 @@ install_page (void *upage, void *kpage, bool writable) {
  * If you want to implement the function for only project 2, implement it on the
  * upper block. */
 
-static bool
+bool
 lazy_load_segment (struct page *page, void *aux) {
 	//printf("[lazy load segment] 실행\n");
 	/* TODO: This called when the first page fault occurs on address VA. */
@@ -725,7 +725,11 @@ lazy_load_segment (struct page *page, void *aux) {
 		return false;
 	}
 	memset(page->frame->kva + page_read_bytes, 0, page_zero_bytes);
-	free(aux);
+	
+	if(page_get_type(page)!=VM_FILE) {
+		free(aux);
+	}
+	
 	//printf("[lazy load segment] end\n");
 	return true;
 

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -210,6 +210,7 @@ void close (int fd) {
 /* The main system call interface */
 void
 syscall_handler (struct intr_frame *f) {
+	//printf("[syscall number] %d\n", f->R.rax);
 	switch (f->R.rax) {
 		case SYS_HALT:
 			halt();

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -22,9 +22,10 @@ void
 vm_anon_init (void) {
 	/* TODO: Set up the swap_disk. */
 	
-	swap_disk = NULL;
+	//swap_disk = NULL;
+
 	// for bitmap?
-	// swap_disk = disk_get(1,1);
+	swap_disk = disk_get(1,1);
 	// disk_size(swap_disk);
 	// and more...
 }
@@ -36,6 +37,7 @@ anon_initializer (struct page *page, enum vm_type type, void *kva) {
 	page->operations = &anon_ops;
 
 	struct anon_page *anon_page = &page->anon;
+	return true;
 }
 
 /* Swap in the page by read contents from the swap disk. */
@@ -54,4 +56,8 @@ anon_swap_out (struct page *page) {
 static void
 anon_destroy (struct page *page) {
 	struct anon_page *anon_page = &page->anon;
+	if(page->frame) {
+		free(page->frame);
+	}
+	return;
 }

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -21,7 +21,12 @@ static const struct page_operations anon_ops = {
 void
 vm_anon_init (void) {
 	/* TODO: Set up the swap_disk. */
+	
 	swap_disk = NULL;
+	// for bitmap?
+	// swap_disk = disk_get(1,1);
+	// disk_size(swap_disk);
+	// and more...
 }
 
 /* Initialize the file mapping */

--- a/vm/file.c
+++ b/vm/file.c
@@ -1,7 +1,10 @@
 /* file.c: Implementation of memory backed file object (mmaped object). */
 
 #include "vm/vm.h"
-
+#include "threads/vaddr.h"
+#include "userprog/process.h"
+#include "threads/mmu.h"
+#include "vm/vm.h"
 static bool file_backed_swap_in (struct page *page, void *kva);
 static bool file_backed_swap_out (struct page *page);
 static void file_backed_destroy (struct page *page);
@@ -14,9 +17,14 @@ static const struct page_operations file_ops = {
 	.type = VM_FILE,
 };
 
+/* mmap */
+static struct lock vmfile_lock;
+void file_write_back(struct page* page, void* addr); 
+
 /* The initializer of file vm */
 void
 vm_file_init (void) {
+	lock_init(&vmfile_lock);
 }
 
 /* Initialize the file backed page */
@@ -38,21 +46,149 @@ file_backed_swap_in (struct page *page, void *kva) {
 static bool
 file_backed_swap_out (struct page *page) {
 	struct file_page *file_page UNUSED = &page->file;
+	//pml4_clear_page
 }
 
 /* Destory the file backed page. PAGE will be freed by the caller. */
 static void
 file_backed_destroy (struct page *page) {
 	struct file_page *file_page UNUSED = &page->file;
+
+	if(file_page == NULL) {
+		return NULL;
+	}
+
+	file_write_back(page, page->va);
+
+	/* set present bit 0 */
+	pml4_clear_page(thread_current()->pml4, page->va);
+
+
 }
 
 /* Do the mmap */
+// lazy loading :: similar with load segment 
 void *
 do_mmap (void *addr, size_t length, int writable,
 		struct file *file, off_t offset) {
+	//printf("[do_mmap] file:%p\n", file);
+	struct file* target_file = file_reopen(file);
+	//printf("[do_mmap] target_file:%p\n", target_file);
+	/* [DIFF with load_segment in process] : to return mapped va*/ 
+	void *start_addr = addr;
+	
+	int total_page_count =
+        length <= PGSIZE
+            ? 1
+            : (length % PGSIZE
+                   ? length / PGSIZE + 1
+                   : length / PGSIZE);  // 이 매핑을 위해 사용한 총 페이지 수
+
+	/* set read and zero bytes */
+	size_t read_bytes, zero_bytes; 
+	
+	// Check given length, if file length is smaller than length, put entire.
+	// If file length is bigger than length, load the size of length only.
+	read_bytes = length > file_length(file) ? file_length(file) : length;
+	// the remain bytes which will be written in the last page
+	zero_bytes = PGSIZE - (read_bytes % PGSIZE);
+
+	ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
+    ASSERT(pg_ofs(addr) == 0);  
+    ASSERT(offset % PGSIZE == 0); 
+
+	int counts = 0;
+
+	while(read_bytes> 0 || zero_bytes> 0) {
+		/* 	   
+		We will read PAGE_READ_BYTES bytes from FILE
+	    and zero the final PAGE_ZERO_BYTES bytes.*/
+		counts++;
+		//printf("[do_mmap] counts: %d\n", counts);
+		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
+		size_t page_zero_bytes = PGSIZE - page_read_bytes;
+
+		/* Set up container to pass information to the lazy_load_segment. */
+		struct load_info* container = (struct load_info*)malloc(sizeof(struct load_info));
+		// insert the given arguments
+		container->file = target_file;
+		container->ofs = offset;
+		container->read_bytes = page_read_bytes;
+		container->zero_bytes = page_zero_bytes;
+		container->writable = writable;
+
+		/* [DIFF with load_segment in process] */ 
+		if (!vm_alloc_page_with_initializer (VM_FILE, addr,
+					writable, lazy_load_segment, container))
+			{	
+				
+				return NULL;}
+
+		struct page *p = spt_find_page(&thread_current()->spt, start_addr);
+        p->mapped_page_count = total_page_count;
+		
+		/* Advance for moving next page */
+		read_bytes -= page_read_bytes;
+		zero_bytes -= page_zero_bytes;
+		addr += PGSIZE;
+		offset += page_read_bytes;
+		
+
+		//printf("[do_mmap] container file addr:%p, addr:%p, container->read_bytes: %d, container->ofs:%d \n", container->file, addr, container->read_bytes, container->ofs);
+		
+	}
+	/* [DIFF with load_segment in process] */ 
+
+	// printf("[do_mmap] container file addr:%p, addr:%p, container->read_bytes: %d, container->ofs:%d \n", container->file, addr, container->read_bytes, container->ofs);
+	//printf("[do_mmap] end start addr:%p\n", start_addr);
+	return start_addr;
+
 }
 
 /* Do the munmap */
 void
 do_munmap (void *addr) {
+	//printf("[do_munmap] started at: %p \n", addr);
+
+	while(true) {
+		//printf("[do_munmap] while \n");
+		struct page *p = spt_find_page(&thread_current()->spt, addr);
+		if(p==NULL){
+			break;
+		}
+		// struct load_info* container = p->uninit.aux;
+		// printf("[do_munmap] container file addr:%p, addr:%p, container->read_bytes: %d, container->ofs:%d \n", container->file, addr, container->read_bytes, container->ofs);
+		file_write_back(p, addr);
+		addr += PGSIZE;
+	}
+
+}
+
+
+void
+file_write_back(struct page* target_page, void* addr) {
+
+	//printf("[file_write_back] started at %p \n", addr);
+
+	if(target_page == NULL) {
+		return NULL;
+	}
+
+	if(target_page->uninit.type != VM_FILE) {
+		return NULL;
+	}
+
+	struct load_info* container = target_page->uninit.aux;
+	//printf("[file_write_back] container file addr:%p, addr:%p, container->read_bytes: %d, container->ofs:%d \n", container->file, addr, container->read_bytes, container->ofs);
+
+	//check the dirty bit
+	if(pml4_is_dirty(thread_current()->pml4, target_page->va)) {
+		//printf("[file_write_back] this page is dirty \n");
+		//write file in the disk
+		lock_acquire(&vmfile_lock);
+		file_write_at(container->file, addr, container->read_bytes, container->ofs);
+		//printf("[file_write_back] lock finished \n");
+		pml4_set_dirty(thread_current()->pml4, target_page->va, 0);
+		lock_release(&vmfile_lock);
+	}
 }

--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -65,4 +65,11 @@ uninit_destroy (struct page *page) {
 	struct uninit_page *uninit UNUSED = &page->uninit;
 	/* TODO: Fill this function.
 	 * TODO: If you don't have anything to do, just return. */
+
+	if(page->uninit.aux != NULL) {
+		free(page->uninit.aux);
+	}
+
+	return;
+
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -3,6 +3,9 @@
 #include "threads/malloc.h"
 #include "vm/vm.h"
 #include "vm/inspect.h"
+/* project 3 */
+#include "lib/kernel/hash.h"
+#include "threads/vaddr.h"
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
@@ -37,6 +40,12 @@ static struct frame *vm_get_victim (void);
 static bool vm_do_claim_page (struct page *page);
 static struct frame *vm_evict_frame (void);
 
+/* project 3 : helpers for hash */
+unsigned page_hash (const struct hash_elem *p_, void *aux UNUSED); 
+bool page_less (const struct hash_elem *a_, const struct hash_elem *b_, void *aux UNUSED); 
+struct page *page_lookup (const void *va, struct supplemental_page_table *spt);
+void hash_copy_table (struct hash_elem *e, void *aux);
+
 /* Create the pending page object with initializer. If you want to create a
  * page, do not create it directly and make it through this function or
  * `vm_alloc_page`. */
@@ -44,27 +53,66 @@ bool
 vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		vm_initializer *init, void *aux) {
 
+//printf("[vm 이름 긴 거] 실행\n");
 	ASSERT (VM_TYPE(type) != VM_UNINIT)
 
 	struct supplemental_page_table *spt = &thread_current ()->spt;
+	struct thread *curr = thread_current();
 
 	/* Check wheter the upage is already occupied or not. */
+	void* upage_va = pg_round_down(upage);
+
 	if (spt_find_page (spt, upage) == NULL) {
-		/* TODO: Create the page, fetch the initialier according to the VM type,
-		 * TODO: and then create "uninit" page struct by calling uninit_new. You
-		 * TODO: should modify the field after calling the uninit_new. */
+		/* Create the page, fetch the initialier according to the VM type*/
+		struct page* new_page = calloc(1, sizeof(struct page));
+
+		if(new_page == NULL){
+			goto err;
+		}
+		
+		 /* TODO: and then create "uninit" page struct by calling uninit_new.*/ 
+		//struct uninit_page* new_uninit_page;
+		uninit_new(new_page, upage_va, init, type, aux, NULL);
+		//printf("[vm 이름 긴 거] uninit_new end\n");
+
+
+		 /* TODO: You should modify the field after calling the uninit_new. */
+		switch(VM_TYPE(type)) {
+			case(VM_ANON):
+				uninit_new(new_page, upage_va, init, type, aux, anon_initializer);
+				new_page->writable = writable;
+				//printf("[vm 이름 긴 거] vm_anon end\n");
+				break;
+			case(VM_FILE):
+				uninit_new(new_page, upage_va, init, type, aux, file_backed_initializer);
+				new_page->writable = writable;
+				//printf("[vm 이름 긴 거] vm_file end\n");
+				break;
+			}
 
 		/* TODO: Insert the page into the spt. */
+		if(!spt_insert_page(spt, new_page)) {
+			//printf("[vm 이름 긴 거] insert page가 망함\n");
+			free(new_page);
+			free(aux);
+			goto err;
+		}
+		//printf("[vm 이름 긴 거] end in true\n");
+		return true;
 	}
 err:
+	//printf("[vm 이름 긴 거] end in false\n");
 	return false;
 }
 
 /* Find VA from spt and return page. On error, return NULL. */
 struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
+	//printf("[spt find page] start\n");
 	struct page *page = NULL;
 	/* TODO: Fill this function. */
+	void* upage_va = pg_round_down(va);
+	page = page_lookup(upage_va, spt);
 
 	return page;
 }
@@ -73,10 +121,8 @@ spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 bool
 spt_insert_page (struct supplemental_page_table *spt UNUSED,
 		struct page *page UNUSED) {
-	int succ = false;
-	/* TODO: Fill this function. */
-
-	return succ;
+	// hash_insert will return NULL if it is succees to insert new one
+	return hash_insert(&spt->spt_hash, &page->hash_elem) == NULL;
 }
 
 void
@@ -108,10 +154,39 @@ vm_evict_frame (void) {
  * and return it. This always return valid address. That is, if the user pool
  * memory is full, this function evicts the frame to get the available memory
  * space.*/
+
 static struct frame *
 vm_get_frame (void) {
-	struct frame *frame = NULL;
+	//printf("[vm_get_frame claim] start\n");
+
 	/* TODO: Fill this function. */
+	// (1) get new PM from user pool in KVA(Kernel Virtual address)
+	// palloc_get_page return the address in KVA
+
+	// (2) allocate frame
+	struct frame *frame = calloc(1, sizeof(struct frame));
+	if(! frame) {
+		PANIC("[1] todo (vm_get_frame / swap out)");
+		//return vm_evict_frame();
+		return NULL;
+	}
+	
+	void* kvaddr = palloc_get_page(PAL_USER | PAL_ZERO);
+	//printf("[vm_get_frame claim] kvaddr passed: %p\n", kvaddr);
+	
+	// (3) init frame's members
+	
+	frame->kva = kvaddr;
+	frame->page = NULL;
+	//frame->page = pml4_get_page(&thread_current()->pml4, kvaddr);
+
+	// (4) 페이지 할당에 실패한 경우 지금은 스왑 아웃을 처리할 필요가 없습니다. 당분간은 이러한 경우를 PANIC("할 일")으로 표시하면 됩니다.
+
+	if(frame->kva == NULL) {
+		PANIC("[2] todo (vm_get_frame / swap out)");
+		return NULL;
+	}
+
 
 	ASSERT (frame != NULL);
 	ASSERT (frame->page == NULL);
@@ -136,7 +211,10 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 	struct page *page = NULL;
 	/* TODO: Validate the fault */
 	/* TODO: Your code goes here */
-
+	if((page =spt_find_page(spt, addr)) == NULL) {
+		printf("[vm_try_handle_fault] page is NULL!\n");
+		false;
+	}
 	return vm_do_claim_page (page);
 }
 
@@ -151,35 +229,85 @@ vm_dealloc_page (struct page *page) {
 /* Claim the page that allocate on VA. */
 bool
 vm_claim_page (void *va UNUSED) {
-	struct page *page = NULL;
+	//printf("[vm_claim] start / va?:%p\n", va);
 	/* TODO: Fill this function */
+	// (1) get roundown va
 
+	//uint8_t prd_va = pg_round_down(va);
+
+	// (2) get page from spt(va->spt->page)
+	struct thread* curr = thread_current();
+	//printf("[vm_claim] prd_va:%p / curr:%p\n", prd_va, curr);
+
+	//printf("[vm_claim] start / va?:%p\n", va);
+	struct page *page = spt_find_page(&curr->spt, va);
+
+	//printf("[vm_claim] page:%p, %p\n", page, page->va);
+	if(page==NULL) {
+
+		return false;
+	}
+		
 	return vm_do_claim_page (page);
 }
 
 /* Claim the PAGE and set up the mmu. */
 static bool
 vm_do_claim_page (struct page *page) {
+	//printf("[vm_do claim] start\n");
+	//(1) get the frame
 	struct frame *frame = vm_get_frame ();
+
+	if(frame == NULL) {
+		//printf("[vm_do claim] frame ==NULL\n");
+		return false;
+	}
 
 	/* Set links */
 	frame->page = page;
 	page->frame = frame;
+	//null checking?
 
-	/* TODO: Insert page table entry to map page's VA to frame's PA. */
-
+	bool res = pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable);
+	//printf("[vm_do claim] res: %d\n", res);
+	
 	return swap_in (page, frame->kva);
 }
 
 /* Initialize new supplemental page table */
 void
 supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) {
+	//printf("[supplemental_page_table_init] 실행\n");
+	struct hash* target_ht = &spt->spt_hash;
+	// (1) init hash table
+	if(! hash_init(target_ht, page_hash, page_less, NULL)) {
+		return NULL;
+	}
+	// (2) 
+	//printf("[supplemental_page_table_init] end\n");
 }
 
+
+//void hash_action_func 
+void hash_copy_table (struct hash_elem *src_e, void *aux) {
+	unsigned src_hash_value = page_hash(src_e, aux);
+	struct hash* dst = aux;
+	
+	
+}
 /* Copy supplemental page table from src to dst */
 bool
 supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
 		struct supplemental_page_table *src UNUSED) {
+			// init src hash
+			if(! hash_init(dst, page_hash, page_less, NULL)) {
+				return false; //failure(NULL) check
+			}
+			
+			struct hash_iterator src_hi, dst_hi;
+			src_hi.hash = &src->spt_hash;
+			dst_hi.hash = &dst->spt_hash;
+
 }
 
 /* Free the resource hold by the supplemental page table */
@@ -187,4 +315,35 @@ void
 supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) {
 	/* TODO: Destroy all the supplemental_page_table hold by thread and
 	 * TODO: writeback all the modified contents to the storage. */
+}
+
+/* project 3 */
+/* hash table functions */
+/* Returns a hash value for page p. */
+unsigned
+page_hash (const struct hash_elem *p_, void *aux UNUSED) {
+  const struct page *p = hash_entry (p_, struct page, hash_elem);
+  return hash_bytes (&p->va, sizeof p->va);
+}
+
+/* Returns true if page a precedes page b. */
+bool
+page_less (const struct hash_elem *a_,
+           const struct hash_elem *b_, void *aux UNUSED) {
+  const struct page *a = hash_entry (a_, struct page, hash_elem);
+  const struct page *b = hash_entry (b_, struct page, hash_elem);
+
+  return a->va < b->va;
+}
+
+/* Returns the page containing the given virtual address, or a null pointer if no such page exists. */
+struct page *
+page_lookup (const void *va, struct supplemental_page_table *spt) {
+  //printf("[page_lookup] start\n");
+  struct page p;
+  struct hash_elem *e;
+
+  p.va = va;
+  e = hash_find (&spt->spt_hash, &p.hash_elem);
+  return e != NULL ? hash_entry (e, struct page, hash_elem) : NULL;
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -110,6 +110,7 @@ spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 	struct page *page = NULL;
 	/* TODO: Fill this function. */
 	page = page_lookup(va, spt);
+	//printf("[spt find page] page:%p\n", page);
 
 	return page;
 }
@@ -438,9 +439,27 @@ err:
 void
 supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) {
 	/* TODO: Destroy all the supplemental_page_table hold by thread */
+	
+
+	// /* TODO: writeback all the modified contents to the storage. */
+	// struct hash_iterator i;
+	// hash_first (&i, &spt->spt_hash);
+	// while (hash_next (&i)) {
+	// 	struct page* target_page = hash_entry(hash_cur(&i), struct page, hash_elem);
+
+	// 	if(target_page->operations->type == VM_FILE) {
+	// 		do_munmap(target_page->va);
+	// 	}
+
+	// // 	destroy(target_page);
+	// }
+	// hash_destroy(&spt->spt_hash, page_free);
+	//hash_clear(&spt->spt_hash, page_free);
+	
+	
 	hash_clear(&spt->spt_hash, page_free);
 
-	/* TODO: writeback all the modified contents to the storage. */
+	//hash_destroy(&spt->spt_hash, page_free);
 }
 
 /* project 3 */


### PR DESCRIPTION
# Succeed implementation list  (134/141)
```
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
pass tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/exec-read
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
pass tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/vm/pt-grow-stack
pass tests/vm/pt-grow-bad
pass tests/vm/pt-big-stk-obj
pass tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
pass tests/vm/pt-write-code
pass tests/vm/pt-write-code2
pass tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
FAIL tests/vm/page-parallel
pass tests/vm/page-merge-seq
pass tests/vm/page-merge-par
pass tests/vm/page-merge-stk
FAIL tests/vm/page-merge-mm
pass tests/vm/page-shuffle
pass tests/vm/mmap-read
pass tests/vm/mmap-close
pass tests/vm/mmap-unmap
pass tests/vm/mmap-overlap
pass tests/vm/mmap-twice
pass tests/vm/mmap-write
pass tests/vm/mmap-ro
pass tests/vm/mmap-exit
pass tests/vm/mmap-shuffle
pass tests/vm/mmap-bad-fd
pass tests/vm/mmap-clean
pass tests/vm/mmap-inherit
pass tests/vm/mmap-misalign
pass tests/vm/mmap-null
pass tests/vm/mmap-over-code
pass tests/vm/mmap-over-data
pass tests/vm/mmap-over-stk
pass tests/vm/mmap-remove
pass tests/vm/mmap-zero
pass tests/vm/mmap-bad-fd2
pass tests/vm/mmap-bad-fd3
pass tests/vm/mmap-zero-len
pass tests/vm/mmap-off
pass tests/vm/mmap-bad-off
pass tests/vm/mmap-kernel
pass tests/vm/lazy-file
pass tests/vm/lazy-anon
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
FAIL tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
pass tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
pass tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
7 of 141 tests failed.
```

# Failed testcases

FAIL tests/vm/page-parallel
FAIL tests/vm/page-merge-mm
FAIL tests/vm/cow/cow-simple
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
FAIL tests/vm/swap-fork

# After plan (If possible)
* Swap I/O implementation : in progress 
* Fix page-parallel / page-merge-mm : consider memory leak & lock issue
* Try cow